### PR TITLE
redefined ndv->res_required

### DIFF
--- a/ST_resgroups.c
+++ b/ST_resgroups.c
@@ -64,33 +64,14 @@ static RealF _add_annuals(const GrpIndex rg, const RealF g_pr,
 void rgroup_PartResources(void)
 {
 	/*======================================================*/
-	/* PURPOSE */
 	/* Partition resources for this year among the resource
 	 groups.  The allocation happens in three steps: basic
-	 group allocation (which is done here), partitioning of
-	 extra resources (in _res_part_extra()), and further
-	 partitioning to individuals in the group (_ResPartIndiv()).
-
-	 See COMMENT 1. at the end of this file for the algorithm.
-
-	 For future documenting reference, note that the one
-	 requirement regarding slope/intercept is that the
-	 Globals.ppt.avg * slope + intercept == 1.0 for all
-	 groups.
-	 */
-	/* HISTORY */
+	 group allocation, partitioning of extra resources in 
+	 _res_part_extra(), and further partitioning to individuals 
+	 in the group _ResPartIndiv().
+    See COMMENT 1. at the end of this file for the algorithm.*/
 	/* Chris Bennett @ LTER-CSU 12/15/2000            */
-	/* This code was transformed from an earlier version's
-	 Env_Partition() and moved here because I'd like to
-	 rewrite the model as a C++ program and the RGroups
-	 will become a class.
-
-	 8-Apr-2003 - cwb -- Well, after ALL this time, it finally
-	 dawned on me to put the resource calculations
-	 into a spreadsheet and figure them out correctly.
-	 Affected lines are g->res_avail, and remains.
-
-	 15-May-03 (cwb) Bill suggested partitioning resource by
+	/* 15-May-03 (cwb) Bill suggested partitioning resource by
 	 mm instead of proportionally, however, the results
 	 aren't precisely the same as the proportional
 	 method, so I'm making code for both methods.
@@ -111,8 +92,6 @@ void rgroup_PartResources(void)
 	GroupType *g; /* shorthand for RGroup[rg] */
 	int i;
 
-	/*----------------------------------------------------*/
-
 	/* ----- distribute basic (minimum) resources */
 	ForEachGroup(rg)
 	{
@@ -122,10 +101,10 @@ void rgroup_PartResources(void)
 			g->relsize = _add_annuals(rg, 1.0, no_seeds);
 
 		/*this piece of the code is only used when SOILWAT is NOT running*/
-#ifdef STEPWAT
+	#ifdef STEPWAT
 		if (!UseSoilwat)
 		{ /* use by-mm method */
-#endif
+	#endif
 		resource = _ppt2resource(Env.ppt, g);
 		g->res_required = g->relsize / g->max_density;
 		g->res_avail = fmin(1., fmin(g->res_required, resource));
@@ -137,12 +116,10 @@ void rgroup_PartResources(void)
 		size_obase[rg] = (g->use_extra_res) ? size_base[rg] : 0.;
 
 		/*this is how res_required and res_avail are set if SOILWAT is running*/
-#ifdef STEPWAT
+	#ifdef STEPWAT
 	}
 	else
 	{
-		/* trick for later pr calc */
-
 		g->res_required = RGroup_GetBiomass(rg);
 		g->res_avail = SXW_GetTranspiration(rg); //1.0;
 		//PR limit can be really high see mort no_resource I limit to the groups estab indiv because that is what we can kill.
@@ -162,12 +139,8 @@ void rgroup_PartResources(void)
         //KAP:Previously, a seperate set of code was used to determine resource availability for annual species
         //Now, resource paritioning for annuals occurs in the same way as for perennials, by getting the RGroup Biomass
         //and the resource_cur from SXW_GetTranspiration
-		//Annuals seem to have a artificial limit of 20. We do Annuals here differently
 		if(g->max_age == 1)
 		{
-			//{	ForEachGroupSpp(sp,rg,i)
-			//	g->res_required += Species[sp]->mature_biomass * .75;}
-			//g->res_avail = SXW_GetTranspiration(rg);
 			if(!ZRO(g->res_avail) && g->res_required / g->res_avail > 20)
 			{
 				g->res_required = 20;
@@ -180,7 +153,8 @@ void rgroup_PartResources(void)
 			}
 		}
 	}
-#endif
+        #endif
+	  
 	  /* If relsize>0, reset noplants from TRUE to FALSE and if noplants=TRUE, exit from the loop */
 		if (GT(g->relsize, 0.))
 			noplants = FALSE;
@@ -195,17 +169,11 @@ void rgroup_PartResources(void)
 		_res_part_extra(do_base, xtra_base, size_base);
 		_res_part_extra(do_extra, xtra_obase, size_obase);
 	
-	/* reset annuals' "true" relative size here */
-    //KAP: formely, this call established annual species. We have moved annual establishment to the Rgroup_Establish function,
-    //where all other resource groups establish (e.g. perennials). This function is no longer required.
+	//calculate PR at the rgroup level: resources required/resources available  
 	ForEachGroup(rg)
 	{
 		g = RGroup[rg];
 		g->pr = ZRO(g->res_avail) ? 0. : g->res_required / g->res_avail;
-		//if (g->max_age == 1)
-		//{
-		//	g->relsize = _add_annuals(rg, g->pr, add_seeds);
-		//}
 	}
 
 	rgroup_ResPartIndiv();
@@ -413,34 +381,15 @@ static void _res_part_extra(Bool isextra, RealF extra, RealF size[])
 void rgroup_ResPartIndiv(void)
 {
 	/*======================================================*/
-	/* PURPOSE */
-	/* The PR value used in the growth loop is now at the
+		/* The PR value used in the growth loop is now at the
 	 individual level rather than the group level, so the
 	 resource availability for the group is divided between
-	 individuals of the group, largest to smallest.  Species
-	 distinctions within the group are ignored.
-
-	 The partitioning of resources to individuals is done
-	 proportionally based on size so that individuals can
-	 have their own PR value.  The reasoning is that larger
-	 individuals should get more resources than their
-	 less-developed competitors.
-
-	 See COMMENT 3 at the end of this file for the algorithm.
-
-	 /* HISTORY
-	 /* Chris Bennett @ LTER-CSU 12/21/2000
-	 Removed from rgroup_PartResources() to simplify that
-	 routine.
-
-	 7-Jul-02 - made this a global function to be called
-	 by the STEPWAT code.  No other changes.
-
-	 2-Mar-03 - changed indivs and res_prop to be local and
-	 dynamically allocated.
-	 - changed the premise of the routine.  see
-	 algorithm comments in Comment 3 for more info.
-	 */
+	 individuals of the group, largest to smallest. Species
+	 distinctions within the group are ignored.The partitioning of resources
+         to individuals is done proportionally based on size so that individuals 
+         should get more resources than their less-developed competitors.
+	 See COMMENT 3 at the end of this file for the algorithm. Chris Bennett 
+         @ LTER-CSU 12/21/2000*/
 
 	/*------------------------------------------------------*/
 
@@ -458,8 +407,6 @@ void rgroup_ResPartIndiv(void)
 	ForEachGroup(rg)
 	{
 		g = RGroup[rg];
-		//if (g->max_age == 1 ) continue;  /* annuals don't have indivs */
-		// removed to give annuals individuals (TEM 10-27-2015)
 		if (!g->est_count)
 			continue;
 
@@ -480,28 +427,29 @@ void rgroup_ResPartIndiv(void)
 				ndv = indivs[n];
 
 				ndv->res_required = (ndv->relsize * Species [sp]->mature_biomass);
-				printf("ndv->res_required = %f\n, Species = %s \n", Species[sp]->name, ndv->res_required);
+				//printf("ndv->res_required = %f\n, Species = %s \n", Species[sp]->name, ndv->res_required);
 
 				if (GT(g->pr, 1.))
 				{
 				ndv->res_avail = fmin(ndv->res_required, base_rem);
-				printf("ndv->res_avail_pr>1 = %f\n", ndv->res_avail);
+				//printf("ndv->res_avail_pr>1 = %f\n", ndv->res_avail);
 
 				base_rem = fmax(base_rem - ndv->res_avail, 0.);
-				printf("base_rem pr>1 = %f\n", base_rem);
+				//printf("base_rem pr>1 = %f\n", base_rem);
 
 				}
 				
 				else
 				{
 				ndv->res_avail = ndv->grp_res_prop * g->res_avail;
-				printf("ndv->res_avail pr <1 = %f\n", ndv->res_avail);
+				//printf("ndv->res_avail pr <1 = %f\n", ndv->res_avail);
 
 				}
 			}
 		}
+		
 		base_rem += fmin(0, g->res_avail - 1.0);
-        printf("base_rem end = %f\n", base_rem);
+        //printf("base_rem end = %f\n", base_rem);
 
 		/* --- compute PR, but on the way, assign extra resource */
 		for (n = 0; n < numindvs; n++)
@@ -511,14 +459,12 @@ void rgroup_ResPartIndiv(void)
 			if (g->use_extra_res)
 			{
 				/* polish off any remaining resource not allocated to extra */
-				ndv->res_avail +=
-						ZRO(base_rem) ? 0. : ndv->grp_res_prop * base_rem;
+				ndv->res_avail += ZRO(base_rem) ? 0. : ndv->grp_res_prop * base_rem;
 				/* extra resource gets assigned here if applicable */
 				if (GT(g->res_extra, 0.))
 				{
 					x = 1. - ndv->relsize;
-					ndv->res_extra = (1. - x) * ndv->grp_res_prop
-							* g->res_extra;
+					ndv->res_extra = (1. - x) * ndv->grp_res_prop* g->res_extra;
 					ndv->res_avail += x * ndv->grp_res_prop * g->res_extra;
 				}
 
@@ -526,7 +472,7 @@ void rgroup_ResPartIndiv(void)
 
 			/* ---- at last!  compute the PR value, or dflt to 100  */
 			ndv->pr = GT(ndv->res_avail, 0.) ? ndv->res_required / ndv->res_avail : 100.;
-			printf("ndv->pr  = %f\n", ndv->pr);
+			//printf("ndv->pr  = %f\n", ndv->pr);
 
 		}
 

--- a/ST_resgroups.c
+++ b/ST_resgroups.c
@@ -446,6 +446,8 @@ void rgroup_ResPartIndiv(void)
 
 	GrpIndex rg;
 	GroupType *g; /* shorthand for RGroup[rg] */
+	SppIndex sp;
+	Int j; 
 	IndivType **indivs, /* dynamic array of indivs in RGroup[rg] */
 	*ndv; /* shorthand for the current indiv */
 	IntS numindvs, n;
@@ -469,23 +471,37 @@ void rgroup_ResPartIndiv(void)
 		/*      amount of extra, if any, is kept in g->res_extra      */
 		/*    base_rem = fmin(1, g->res_avail);  */
 		base_rem = g->res_avail;
-		for (n = 0; n < numindvs; n++)
+		
+		ForEachEstSpp(sp, rg, j)
 		{
-			ndv = indivs[n];
+		
+			for (n = 0; n < numindvs; n++)
+			{
+				ndv = indivs[n];
 
-			ndv->res_required = (ndv->relsize / g->max_spp) / g->estabs;
-			if (GT(g->pr, 1.))
-			{
+				ndv->res_required = (ndv->relsize * Species [sp]->mature_biomass);
+				printf("ndv->res_required = %f\n, Species = %s \n", Species[sp]->name, ndv->res_required);
+
+				if (GT(g->pr, 1.))
+				{
 				ndv->res_avail = fmin(ndv->res_required, base_rem);
+				printf("ndv->res_avail_pr>1 = %f\n", ndv->res_avail);
+
 				base_rem = fmax(base_rem - ndv->res_avail, 0.);
-			}
-			else
-			{
+				printf("base_rem pr>1 = %f\n", base_rem);
+
+				}
+				
+				else
+				{
 				ndv->res_avail = ndv->grp_res_prop * g->res_avail;
+				printf("ndv->res_avail pr <1 = %f\n", ndv->res_avail);
+
+				}
 			}
 		}
-
 		base_rem += fmin(0, g->res_avail - 1.0);
+        printf("base_rem end = %f\n", base_rem);
 
 		/* --- compute PR, but on the way, assign extra resource */
 		for (n = 0; n < numindvs; n++)
@@ -509,9 +525,9 @@ void rgroup_ResPartIndiv(void)
 			}
 
 			/* ---- at last!  compute the PR value, or dflt to 100  */
-			ndv->pr =
-					GT(ndv->res_avail, 0.) ?
-							ndv->res_required / ndv->res_avail : 100.;
+			ndv->pr = GT(ndv->res_avail, 0.) ? ndv->res_required / ndv->res_avail : 100.;
+			printf("ndv->pr  = %f\n", ndv->pr);
+
 		}
 
 		Mem_Free(indivs);


### PR DESCRIPTION
ndv->res_resquired is now based on biomass rather than relsize. This
will appropriately scale ndv->res_required with g->res_required and
ndv->res_avail. See issue #38 on Github.