### PR TITLE
Feature soilwat2 with co2

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,4 +1,5 @@
 [submodule "sw_src"]
 	path = sw_src
 	url = https://github.com/Burke-Lauenroth-Lab/SOILWAT2.git
+	branch = soilwat_co2_effects
         ignore = dirty

--- a/.gitmodules
+++ b/.gitmodules
@@ -1,5 +1,5 @@
 [submodule "sw_src"]
 	path = sw_src
 	url = https://github.com/Burke-Lauenroth-Lab/SOILWAT2.git
-	branch = soilwat_co2_effects
+	branch = master
         ignore = dirty

--- a/makefile
+++ b/makefile
@@ -238,7 +238,7 @@ $(oDir)/sw_src/SW_VegProd.o: sw_src/SW_VegProd.c sw_src/generic.h \
  sw_src/SW_VegProd.h
 	$(CC) $(C_FLAGS) $(incDirs) -c -o $@ $<
 
-$(oDir)/sw_src/SW_Carbon.o: sw_src/SW_VegProd.c sw_src/generic.h \
+$(oDir)/sw_src/SW_Carbon.o: sw_src/SW_Carbon.c sw_src/generic.h \
  sw_src/filefuncs.h sw_src/SW_Defines.h sw_src/SW_Files.h sw_src/SW_Times.h \
  sw_src/SW_Carbon.h sw_src/SW_VegProd.h sw_src/SW_Model.h
 	$(CC) $(C_FLAGS) $(incDirs) -c -o $@ $<

--- a/makefile
+++ b/makefile
@@ -16,7 +16,7 @@ CC  	=	gcc
 
 WRES	=	windres #no idea what this was actually used for since it doesn't do anything...
 
-HOMEV	=	
+HOMEV	=
 VPATH	=	$(HOMEV)/include #no idea what this was used for either...
 oDir	=	./obj
 Bin	=	.
@@ -25,7 +25,7 @@ libDirs	=	-Lsw_src -Lsqlite-amalgamation
 
 incDirs	=	-Isw_src -Isqlite-amalgamation
 
-LIBS	=	
+LIBS	=
 C_FLAGS	=	-g  -O0 -Wstrict-prototypes -Wmissing-prototypes -Wimplicit -Wunused -Wformat -Wredundant-decls -Wcast-align\
 	-DSTEPWAT -lm
 
@@ -50,6 +50,7 @@ SRCS	=\
 	$(Src)/sw_src/SW_Site.c\
 	$(Src)/sw_src/SW_Sky.c\
 	$(Src)/sw_src/SW_VegProd.c\
+	$(Src)/sw_src/SW_Carbon.c\
 	$(Src)/sw_src/SW_Flow_lib.c\
 	$(Src)/sw_src/SW_Flow.c\
 	$(Src)/ST_environs.c\
@@ -88,6 +89,7 @@ EXOBJS	=\
 	$(oDir)/sw_src/SW_Site.o\
 	$(oDir)/sw_src/SW_Sky.o\
 	$(oDir)/sw_src/SW_VegProd.o\
+	$(oDir)/sw_src/SW_Carbon.o\
 	$(oDir)/sw_src/SW_Flow_lib.o\
 	$(oDir)/sw_src/SW_Flow.o\
 	$(oDir)/ST_environs.o\
@@ -171,9 +173,9 @@ $(oDir)/sxw.o: sxw.c sw_src/generic.h sw_src/filefuncs.h \
  sw_src/myMemory.h ST_steppe.h ST_defines.h ST_structs.h \
  ST_functions.h ST_globals.h sw_src/SW_Defines.h sxw.h sw_src/SW_Times.h sxw_funcs.h \
  sxw_module.h sw_src/SW_Control.h sw_src/SW_Model.h sw_src/SW_Site.h sw_src/SW_SoilWater.h \
- sw_src/SW_Files.h sw_src/SW_VegProd.h
+ sw_src/SW_Files.h sw_src/SW_VegProd.h sw_src/SW_Carbon.h
 	$(CC) $(C_FLAGS) $(incDirs) -c -o $@ $<
-	
+
 $(oDir)/sxw_sql.o: sxw_sql.c ST_steppe.h \
  ST_steppe.h sw_src/SW_Defines.h sxw.h\
  sw_src/SW_Times.h sxw_module.h sw_src/SW_Model.h sw_src/SW_Site.h sw_src/SW_SoilWater.h
@@ -217,14 +219,14 @@ $(oDir)/sw_src/SW_Model.o: sw_src/SW_Model.c sw_src/generic.h sw_src/filefuncs.h
 $(oDir)/sw_src/SW_Output.o: sw_src/SW_Output.c sw_src/generic.h \
  sw_src/filefuncs.h sw_src/myMemory.h sw_src/SW_Defines.h \
  sw_src/SW_Files.h sw_src/SW_Model.h sw_src/SW_Times.h sw_src/SW_Site.h sw_src/SW_SoilWater.h sw_src/SW_Output.h \
- sw_src/SW_Weather.h
+ sw_src/SW_Weather.h sw_src/SW_Carbon.h
 	$(CC) $(C_FLAGS) $(incDirs) -c -o $@ $<
-	
-$(oDir)/sw_src/SW_Main_Function.o: sw_src/SW_Main_Function.c 
-	$(CC) $(C_FLAGS) $(incDirs) -c -o $@ $<	
+
+$(oDir)/sw_src/SW_Main_Function.o: sw_src/SW_Main_Function.c
+	$(CC) $(C_FLAGS) $(incDirs) -c -o $@ $<
 
 $(oDir)/sw_src/SW_Site.o: sw_src/SW_Site.c sw_src/generic.h sw_src/filefuncs.h \
- sw_src/myMemory.h sw_src/SW_Defines.h sw_src/SW_Files.h sw_src/SW_Site.h
+ sw_src/myMemory.h sw_src/SW_Defines.h sw_src/SW_Files.h sw_src/SW_Site.h sw_src/SW_Carbon.h
 	$(CC) $(C_FLAGS) $(incDirs) -c -o $@ $<
 
 $(oDir)/sw_src/SW_Sky.o: sw_src/SW_Sky.c sw_src/generic.h sw_src/filefuncs.h \
@@ -234,6 +236,11 @@ $(oDir)/sw_src/SW_Sky.o: sw_src/SW_Sky.c sw_src/generic.h sw_src/filefuncs.h \
 $(oDir)/sw_src/SW_VegProd.o: sw_src/SW_VegProd.c sw_src/generic.h \
  sw_src/filefuncs.h sw_src/SW_Defines.h sw_src/SW_Files.h sw_src/SW_Times.h \
  sw_src/SW_VegProd.h
+	$(CC) $(C_FLAGS) $(incDirs) -c -o $@ $<
+
+$(oDir)/sw_src/SW_Carbon.o: sw_src/SW_VegProd.c sw_src/generic.h \
+ sw_src/filefuncs.h sw_src/SW_Defines.h sw_src/SW_Files.h sw_src/SW_Times.h \
+ sw_src/SW_Carbon.h sw_src/SW_VegProd.h sw_src/SW_Model.h
 	$(CC) $(C_FLAGS) $(incDirs) -c -o $@ $<
 
 $(oDir)/sw_src/SW_Flow.o: sw_src/SW_Flow.c sw_src/generic.h sw_src/filefuncs.h \
@@ -248,7 +255,7 @@ $(oDir)/ST_environs.o: ST_environs.c ST_steppe.h ST_defines.h \
 
 $(oDir)/sw_src/SW_Control.o: sw_src/SW_Control.c sw_src/generic.h \
  sw_src/filefuncs.h sw_src/rands.h sw_src/SW_Defines.h sw_src/SW_Files.h \
- sw_src/SW_Control.h sw_src/SW_Model.h sw_src/SW_Times.h sw_src/SW_Output.h sw_src/SW_Site.h \
+  sw_src/SW_Carbon.h sw_src/SW_Control.h sw_src/SW_Model.h sw_src/SW_Times.h sw_src/SW_Output.h sw_src/SW_Site.h \
  sw_src/SW_SoilWater.h sw_src/SW_VegProd.h sw_src/SW_Weather.h
 	$(CC) $(C_FLAGS) $(incDirs) -c -o $@ $<
 
@@ -303,7 +310,7 @@ $(oDir)/ST_stats.o: ST_stats.c ST_steppe.h ST_defines.h sw_src/generic.h \
 #	$(CC) $(C_FLAGS) $(incDirs) -c -o $@ $<
 
 $(oDir)/sw_src/SW_Flow_lib.o: sw_src/SW_Flow_lib.c sw_src/generic.h sw_src/SW_Defines.h \
- sw_src/SW_Flow_lib.h
+ sw_src/SW_Flow_lib.h sw_src/SW_Carbon.h
 	$(CC) $(C_FLAGS) $(incDirs) -c -o $@ $<
 
 $(oDir)/sxw_tester.o: sxw_tester.c sw_src/generic.h \
@@ -311,16 +318,16 @@ $(oDir)/sxw_tester.o: sxw_tester.c sw_src/generic.h \
  ST_defines.h ST_structs.h ST_functions.h ST_Globals.h sw_src/SW_Defines.h \
  sw_src/SW_Site.h sxw_funcs.h sxw.h sw_src/SW_Times.h sxw_module.h sxw_vars.h
 	$(CC) $(C_FLAGS) $(incDirs) -c -o $@ $<
-	
+
 $(oDir)/sw_src/SW_VegEstab.o: sw_src/SW_VegEstab.c sw_src/generic.h sw_src/filefuncs.h sw_src/myMemory.h \
 	sw_src/SW_Defines.h sw_src/SW_Files.h sw_src/SW_Site.h sw_src/SW_Times.h \
 	sw_src/SW_Model.h sw_src/SW_SoilWater.h sw_src/SW_Weather.h sw_src/SW_VegEstab.h
 		$(CC) $(C_FLAGS) $(incDirs) -c -o $@ $<
-		
+
 $(oDir)/ST_grid.o: ST_grid.c ST_steppe.h ST_defines.h sw_src/generic.h \
  ST_globals.h \
  sw_src/myMemory.h ST_globals.h
 	$(CC) $(C_FLAGS) $(incDirs) -c -o $@ $<
-	
+
 $(oDir)/ST_sql.o: ST_sql.c ST_steppe.h ST_globals.h
 	$(CC) $(C_FLAGS) $(incDirs) -c -o $@ $<

--- a/sxw.c
+++ b/sxw.c
@@ -64,6 +64,7 @@
 #include "sw_src/SW_Control.h"
 #include "sw_src/SW_Model.h"
 #include "sw_src/SW_VegProd.h"
+#include "sw_src/SW_Carbon.h"
 #include "sw_src/SW_Site.h"
 #include "sw_src/SW_SoilWater.h"
 #include "sw_src/SW_Files.h"

--- a/sxw.c
+++ b/sxw.c
@@ -336,7 +336,7 @@ void SXW_SW_Setup_Echo(void) {
 	FILE *f = OpenFile(strcat(name, ".input.out"), "a");
 	int i;
 	fprintf(f, "\n================== %d =============================\n", SW_Model.year);
-	fprintf(f,"Fractions Grass:%f Shrub:%f Tree:%f Forb:%f BareGround:%f\n", SW_VegProd.fractionGrass, SW_VegProd.fractionShrub, SW_VegProd.fractionTree, SW_VegProd.fractionForb, SW_VegProd.fractionBareGround);
+	fprintf(f,"Fractions Grass:%f Shrub:%f Tree:%f Forb:%f BareGround:%f\n", SW_VegProd.grass.cov.fCover, SW_VegProd.shrub.cov.fCover, SW_VegProd.tree.cov.fCover, SW_VegProd.forb.cov.fCover, SW_VegProd.bare_cov.fCover);
 	fprintf(f,"Monthly Production Values\n");
 	fprintf(f,"Grass\n");
 	fprintf(f,"Month\tLitter\tBiomass\tPLive\tLAI_conv\n");

--- a/sxw_soilwat.c
+++ b/sxw_soilwat.c
@@ -300,18 +300,18 @@ static void _update_productivity(void) {
 	if (GT(totbmass, 0.)) {
 		//if (ZRO(biomass))
 		//	biomass = 1;
-		v->fractionTree = (vegTypeBiomass[0] / totbmass);
-		v->fractionShrub = (vegTypeBiomass[1] / totbmass);
-		v->fractionGrass = (vegTypeBiomass[2] / totbmass);
-		v->fractionForb = (vegTypeBiomass[3] / totbmass);
+		v->tree.cov.fCover = (vegTypeBiomass[0] / totbmass);
+		v->shrub.cov.fCover = (vegTypeBiomass[1] / totbmass);
+		v->grass.cov.fCover = (vegTypeBiomass[2] / totbmass);
+		v->forb.cov.fCover = (vegTypeBiomass[3] / totbmass);
 		//TODO: figure how to calculate bareground fraction.
-		v->fractionBareGround = 0;
+		v->bare_cov.fCover = 0;
 	} else {
-		v->fractionTree = (0.0);
-		v->fractionShrub = (0.0);
-		v->fractionGrass = (0.0);
-		v->fractionForb = (0.0);
-		v->fractionBareGround = 1;
+		v->tree.cov.fCover = (0.0);
+		v->shrub.cov.fCover = (0.0);
+		v->grass.cov.fCover = (0.0);
+		v->forb.cov.fCover = (0.0);
+		v->bare_cov.fCover = 1;
 	}
 #undef Biomass
 }

--- a/sxw_sql.c
+++ b/sxw_sql.c
@@ -221,7 +221,7 @@ void insertInputVars() {
 	SW_VEGPROD *v = &SW_VegProd;
 
 	beginTransaction();
-	insertSXWinputVarsRow(Year, Iteration, v->fractionGrass, v->fractionShrub, v->fractionTree, v->fractionForb, v->fractionBareGround);
+	insertSXWinputVarsRow(Year, Iteration, v->grass.cov.fCover, v->shrub.cov.fCover, v->tree.cov.fCover, v->forb.cov.fCover, v->bare_cov.fCover);
 	endTransaction();
 }
 

--- a/testing.sagebrush.master/Stepwat_Inputs/Input/sxw/Input/sbe_prod_v31.in
+++ b/testing.sagebrush.master/Stepwat_Inputs/Input/sxw/Input/sbe_prod_v31.in
@@ -1,5 +1,5 @@
 # Plant production data file for SOILWAT
-# Location:  
+# Location:
 
 # ---- Composition of vegetation type components (0-1; must add up to 1)
 # Grasses	Shrubs		Trees		Forbs		Bare Ground
@@ -22,7 +22,7 @@
 29.5		5.0			5.0     	29.5	# yinflec
 85.			100.		3000.		85.		# range
 0.002		0.003		0.00008 	0.002	# slope
-0.			50.			1200.		0.		# if > 0 then constant canopy height (cm)		
+0.			50.			1200.		0.		# if > 0 then constant canopy height (cm)
 
 
 # --- Vegetation interception parameters for equation: intercepted rain = (a + b*veg) + (c+d*veg) * ppt; Grasses+Shrubs: veg=vegcov, Trees: veg=LAI
@@ -51,7 +51,7 @@
 999.0		999.0		2099.0		999.0	#
 
 
-# --- Shade effects on transpiration based on live and dead biomass 
+# --- Shade effects on transpiration based on live and dead biomass
 # Grasses	Shrubs		Trees		Forbs
 0.3			0.3			0.3			0.3		# shade scale
 150.		150.		150.		150.	# shade maximal dead biomass
@@ -72,6 +72,16 @@
 # ---- Critical soil water potential (MPa), i.e., when transpiration rates cannot sustained anymore, for instance, for many crop species -1.5 MPa is assumed and called wilting point
 # Grasses	Shrubs		Trees		Forbs
 -3.5		-3.9		-2.0		-2.0
+
+
+# ---- CO2 Coefficients: multiplier = Coeff1 * x^Coeff2
+# Coefficients assume that monthly biomass inputs reflect values for conditions at
+# 360 ppm CO2, i.e., multiplier = 1 for x = 360 ppm CO2
+# Grasses  Shrubs  Trees  Forbs
+  0.1319  0.1319  0.1319 0.1319  # Biomass Coeff1
+  0.3442  0.3442  0.3442 0.3442  # Biomass Coeff2
+  25.158  25.158  25.158 25.158  # WUE Coeff1
+  -0.548  -0.548  -0.548 -0.548  # WUE Coeff2
 
 
 # Grasslands component:

--- a/testing.sagebrush.master/Stepwat_Inputs/Input/sxw/Input/siteparam_v26.in
+++ b/testing.sagebrush.master/Stepwat_Inputs/Input/sxw/Input/siteparam_v26.in
@@ -9,6 +9,7 @@
 			#   if deepdrain == 1, model expects extra layer in soils file.
 1.0			# multiplier for PET (eg for climate change).
 0.0			#proportion of ponded surface water removed as runoff daily (value ranges between 0 and 1; 0=no loss of surface water, 1=all ponded water lost via runoff)
+0.0			#proportion of water that arrives at surface added as daily runon [from a hypothetical identical neighboring site] (value ranges between 0 and +inf; 0=no runon, >0: runon is occuring)
 
 # ---- Snow simulation parameters (SWAT2K model): Neitsch S, Arnold J, Kiniry J, Williams J. 2005. Soil and water assessment tool (SWAT) theoretical documentation. version 2005. Blackland Research Center, Texas Agricultural Experiment Station: Temple, TX.
 # these parameters are RMSE optimized values for 10 random SNOTEL sites for western US

--- a/testing.sagebrush.master/Stepwat_Inputs/Input/sxw/Input/siteparam_v26.in
+++ b/testing.sagebrush.master/Stepwat_Inputs/Input/sxw/Input/siteparam_v26.in
@@ -1,7 +1,7 @@
 # ---- SWC limits ----
 -1.0			# swc_min : cm/cm if 0 - <1.0, -bars if >= 1.0.; if < 0. then estimate residual water content for each layer
-15.0			# swc_init: cm/cm if < 1.0, -bars if >= 1.0. 
-15.0			# swc_wet : cm/cm if < 1.0, -bars if >= 1.0. 
+15.0			# swc_init: cm/cm if < 1.0, -bars if >= 1.0.
+15.0			# swc_wet : cm/cm if < 1.0, -bars if >= 1.0.
 
 # ---- Model flags and coefficients ----
 0			# reset (1/0): reset/don't reset swc each new year
@@ -27,10 +27,10 @@
 # These control the tangent function (tanfunc) which affects the amount of soil
 # water extractable by evaporation and transpiration.
 # These constants aren't documented by the ELM doc.
-45.          # rate shift (x value of inflection point).  lower value shifts curve 
+45.          # rate shift (x value of inflection point).  lower value shifts curve
              # leftward, meaning less water lost to evap at a given swp.  effectively
              # shortens/extends high rate.
-.1          # rate slope: lower value (eg .01) straightens S shape meaning more gradual 
+.1          # rate slope: lower value (eg .01) straightens S shape meaning more gradual
              # reduction effect; higher value (.5) makes abrupt transition
 .25           # inflection point (y-value of inflection point)
 0.5          # range: diff btw upper and lower rates at the limits
@@ -62,10 +62,18 @@
 990.		# max depth for the soil_temperature function equation, default is 180.  this number should be evenly divisible by deltaX
 0			# flag, 1 to calculate soil_temperature, 0 to not calculate soil_temperature
 
+# ---- CO2 Settings ----
+# Use biomass multiplier
+0
+# Use water-usage efficiency multiplier
+0
+# Scenario
+RCP85
+
 
 # ---- Transpiration regions ----
 # ndx  : 1=shallow, 2=medium, 3=deep, 4=very deep
-# layer: deepest layer number of the region. 
+# layer: deepest layer number of the region.
 # Grasses	Shrubs		Trees		Forbs
 #        Layers are defined in soils.in.
 # ndx    layer

--- a/testing.sagebrush.master/Stepwat_Inputs/Input/sxw/files_v30.in
+++ b/testing.sagebrush.master/Stepwat_Inputs/Input/sxw/files_v30.in
@@ -1,5 +1,5 @@
 # List of input files for SOILWAT v32
-# This is the first file read. Simulation information = 
+# This is the first file read. Simulation information =
 
 # Model
 Input/years.in	# years for model operation
@@ -19,6 +19,9 @@ Input/randomdata/cloud_v20.in	# general atmospheric params
 #Vegetation
 Input/sbe_prod_v31.in	# productivity values
 Input/estab.in	# plant establishment start file
+
+#CO2
+Input/carbon.in
 
 #SWC measurements
 Input/swcsetup.in	# params for handling measured swc


### PR DESCRIPTION
Adjust code so that the CO2-enabled version of SOILWAT2 can be used as submodule (currently tracking the soilwat_co2_effects branch of SOILWAT2).

This PR compiles and the testing example runs well and produces output similar to the output generated by https://github.com/Burke-Lauenroth-Lab/STEPWAT2/pull/50